### PR TITLE
Adding (warning) note to docstring

### DIFF
--- a/mergersecondfuns.py
+++ b/mergersecondfuns.py
@@ -236,6 +236,9 @@ def polarisation_stitching(final_i_index,i_Aorth,i_Adiag,m_Aorth,m_Adiag):
     """
     Stitching together the inspiral and merger/ringdown portions of the
     polarisation lists to give combined lists with the correct matching.
+    NOTE: This (and/or merger_polarisations) needs reworking as there is a
+    jump in the polarisatons at the inspiral-merger transition using this
+    version.
     
     Parameters
     ----------


### PR DESCRIPTION
These were split into a separate development branch to allow the overall refactoring to continue on the main one, because the merger portion polarisations do not match smoothly with the inspiral ones (presumably because they aren't just a simple cos/sin of the phase variable in the inspiral) and there isn't an obvious fix based on Buskirk and Huerta.