### PR TITLE
Strain polarisations for merger/ringdown

### DIFF
--- a/docs/riroriro/mergersecondfuns.rst
+++ b/docs/riroriro/mergersecondfuns.rst
@@ -122,3 +122,66 @@ Returns
 i_m_amp: list of floats
     The values of the amplitude of the GW strain over time for the entire
     duration of the gravitational waveform.
+
+merger_polarisations
+====================
+
+``merger_polarisations(final_i_index,m_amp,m_phase,i_Aorth)``
+
+Calculating the values of the two polarisations of strain for the merger.
+
+Parameters
+----------
+final_i_index: int
+    The last index in the inspiral data before the switch to the merger/
+    ringdown, from final_i_index_finder() in matchingfuns.
+m_amp: list of floats
+    The values of the amplitude of the GW strain over time for the
+    merger/ringdown portion, from merger_strain_amplitude().
+m_phase: list of floats
+    Values of orbital phase over time for the merger/ringdown portion, from
+    merger_phase_calculation().
+i_Aorth: list of floats
+    The values of the orthogonal/plus polarisation of strain over time for
+    the inspiral portion, from inspiral_strain_polarisations() in
+    inspiralfuns.
+    
+Returns
+-------
+[m_Aorth,m_Adiag]: list of lists of floats
+    The first list is the values of the orthogonal/plus polarisation of
+    strain over time, the second list is the diagonal/cross polarisation.
+
+polarisation_stitching
+======================
+
+``polarisation_stitching(final_i_index,i_Aorth,i_Adiag,m_Aorth,m_Adiag)``
+
+Stitching together the inspiral and merger/ringdown portions of the
+polarisation lists to give combined lists with the correct matching.
+
+Parameters
+----------
+final_i_index: int
+    The last index in the inspiral data before the switch to the merger/
+    ringdown, from final_i_index_finder() in matchingfuns.
+i_Aorth: list of floats
+    The values of the orthogonal/plus polarisation of strain over time for
+    the inspiral portion, from inspiral_strain_polarisations() in
+    inspiralfuns.
+i_Adiag: list of floats
+    The values of the diagonal/cross polarisation of strain over time for
+    the inspiral portion, from inspiral_strain_polarisations() in
+    inspiralfuns.
+m_Aorth: list of floats
+    The values of the orthogonal/plus polarisation of strain over time for
+    the merger/ringdown portion, from merger_polarisations().
+m_Adiag: list of floats
+    The values of the diagonal/cross polarisation of strain over time for
+    the merger/ringdown portion, from merger_polarisations().
+    
+Returns
+-------
+[i_m_Aorth,i_m_Adiag]: list of lists of floats
+    The first list is the combined orthogonal/plus polarisation values, the
+    second list is the combined diagonal/cross polarisation values.

--- a/riroriro/mergersecondfuns.py
+++ b/riroriro/mergersecondfuns.py
@@ -222,6 +222,7 @@ def merger_polarisations(final_i_index,m_amp,m_phase,i_Aorth):
     assert type(final_i_index) == int, 'final_i_index should be an int.'
     assert type(m_amp) == list, 'm_amp should be a list.'
     assert type(m_phase) == list, 'm_phase should be a list.'
+    assert type(i_Aorth) == list, 'i_Aorth should be a list.' 
     
     m_Aorth = np.empty((len(m_amp)))            #orthogonal/plus polarisation
     m_Adiag = np.empty((len(m_amp)))            #diagonal/cross polarisation

--- a/riroriro/tests/test_mergersecondfuns.py
+++ b/riroriro/tests/test_mergersecondfuns.py
@@ -15,4 +15,7 @@ def test_mergersecondfuns_errors():
     with pytest.raises(AssertionError):
         me2.merger_phase_calculation(1.4,1,[0,2],[0.2])
         
+    with pytest.raises(TypeError):
+        me2.merger_polarisations(0,[0.2],[0.2])
+        
     print('test_mergersecondfuns_errors completed successfully')


### PR DESCRIPTION
This function was already on the "fourier" development branch, but could be published on "main" without requiring any of the still under-construction functions on that development branch.